### PR TITLE
Expose hitTestBehaviour param

### DIFF
--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -109,7 +109,7 @@ class _PDFState extends State<PDF> {
 
   String getFileName() {
     if(widget.filename?.isEmpty ?? true){
-      getLetterAndDigits(widget.assetsPath ?? widget.networkURL)
+      getLetterAndDigits(widget.assetsPath ?? widget.networkURL);
     }
     else{
       return getLetterAndDigits(widget.assetsPath ?? widget.filename);

--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -20,6 +20,7 @@ class PDF extends StatefulWidget {
     this.height = 250,
     this.placeHolder,
     this.hitTestBehavior,
+    this.filename,
   });
 
   /// Load PDF from network
@@ -30,6 +31,7 @@ class PDF extends StatefulWidget {
     double height = 250,
     Widget placeHolder,
     PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
+    String filename
   }) {
     return PDF._(
       networkURL: url,
@@ -37,6 +39,7 @@ class PDF extends StatefulWidget {
       height: height,
       placeHolder: placeHolder,
       hitTestBehavior: hitTestBehavior,
+      filename: filename,
     );
   }
 
@@ -49,6 +52,7 @@ class PDF extends StatefulWidget {
     double height = 250,
     Widget placeHolder,
     PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
+    String filename
   }) {
     return PDF._(
       file: file,
@@ -56,6 +60,7 @@ class PDF extends StatefulWidget {
       height: height,
       placeHolder: placeHolder,
       hitTestBehavior: hitTestBehavior,
+      filename: filename
     );
   }
 
@@ -68,6 +73,7 @@ class PDF extends StatefulWidget {
     double height = 250,
     Widget placeHolder,
     PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
+    String filename
   }) {
     return PDF._(
       assetsPath: assetPath,
@@ -75,6 +81,7 @@ class PDF extends StatefulWidget {
       height: height,
       placeHolder: placeHolder,
       hitTestBehavior: hitTestBehavior,
+      filename: filename
     );
   }
 
@@ -85,6 +92,7 @@ class PDF extends StatefulWidget {
   final double width;
   final Widget placeHolder;
   final PlatformViewHitTestBehavior hitTestBehavior;
+  final String filename;
 
   @override
   _PDFState createState() => _PDFState();
@@ -100,8 +108,13 @@ class _PDFState extends State<PDF> {
   }
 
   String getFileName() {
-    final baseUrl = widget.networkURL.split('?'); //S3 PresignedURL too long to store, remove the params from url and only use base up to document name
-    return getLetterAndDigits(widget.assetsPath ?? baseUrl[0]);
+    if(widget.filename?.isEmpty ?? true){
+      getLetterAndDigits(widget.assetsPath ?? widget.networkURL)
+    }
+    else{
+      return getLetterAndDigits(widget.assetsPath ?? widget.networkURL);
+    }
+
   }
 
   String getLetterAndDigits(String input) {

--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -29,7 +29,7 @@ class PDF extends StatefulWidget {
     double width = 150,
     double height = 250,
     Widget placeHolder,
-    PlatformViewHitTestBehavior hitTestBehavior,
+    PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
   }) {
     return PDF._(
       networkURL: url,
@@ -48,7 +48,7 @@ class PDF extends StatefulWidget {
     double width = 150,
     double height = 250,
     Widget placeHolder,
-    PlatformViewHitTestBehavior hitTestBehavior,
+    PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
   }) {
     return PDF._(
       file: file,
@@ -67,7 +67,7 @@ class PDF extends StatefulWidget {
     double width = 150,
     double height = 250,
     Widget placeHolder,
-    PlatformViewHitTestBehavior hitTestBehavior,
+    PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
   }) {
     return PDF._(
       assetsPath: assetPath,

--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -112,7 +112,7 @@ class _PDFState extends State<PDF> {
       getLetterAndDigits(widget.assetsPath ?? widget.networkURL)
     }
     else{
-      return getLetterAndDigits(widget.assetsPath ?? widget.networkURL);
+      return getLetterAndDigits(widget.assetsPath ?? widget.filename);
     }
 
   }

--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
@@ -18,22 +19,25 @@ class PDF extends StatefulWidget {
     this.width = 150,
     this.height = 250,
     this.placeHolder,
+    this.hitTestBehavior,
   });
 
   /// Load PDF from network
   /// url : the URL of pdf file
   /// placeholder : Widget to show when pdf is loading from network.
-  factory PDF.network(
-    String url, {
+  factory PDF.network(String url, {
     double width = 150,
     double height = 250,
     Widget placeHolder,
+    PlatformViewHitTestBehavior hitTestBehavior,
   }) {
     return PDF._(
-        networkURL: url,
-        width: width,
-        height: height,
-        placeHolder: placeHolder);
+      networkURL: url,
+      width: width,
+      height: height,
+      placeHolder: placeHolder,
+      hitTestBehavior: hitTestBehavior,
+    );
   }
 
   /// Load PDF from network
@@ -44,12 +48,14 @@ class PDF extends StatefulWidget {
     double width = 150,
     double height = 250,
     Widget placeHolder,
+    PlatformViewHitTestBehavior hitTestBehavior,
   }) {
     return PDF._(
       file: file,
       width: width,
       height: height,
       placeHolder: placeHolder,
+      hitTestBehavior: hitTestBehavior,
     );
   }
 
@@ -61,12 +67,15 @@ class PDF extends StatefulWidget {
     double width = 150,
     double height = 250,
     Widget placeHolder,
+    PlatformViewHitTestBehavior hitTestBehavior,
   }) {
     return PDF._(
-        assetsPath: assetPath,
-        width: width,
-        height: height,
-        placeHolder: placeHolder);
+      assetsPath: assetPath,
+      width: width,
+      height: height,
+      placeHolder: placeHolder,
+      hitTestBehavior: hitTestBehavior,
+    );
   }
 
   final String networkURL;
@@ -75,6 +84,7 @@ class PDF extends StatefulWidget {
   final double height;
   final double width;
   final Widget placeHolder;
+  final PlatformViewHitTestBehavior hitTestBehavior;
 
   @override
   _PDFState createState() => _PDFState();
@@ -160,6 +170,7 @@ class _PDFState extends State<PDF> {
                   onPdfViewerCreated: () {
                     print("PDF view created");
                   },
+                  hitTestBehavior: widget.hitTestBehavior,
                 ),
               )
             : Container(
@@ -184,10 +195,12 @@ class PdfViewer extends StatefulWidget {
     Key key,
     this.filePath,
     this.onPdfViewerCreated,
+    this.hitTestBehavior,
   }) : super(key: key);
 
   final String filePath;
   final PdfViewerCreatedCallback onPdfViewerCreated;
+  final PlatformViewHitTestBehavior hitTestBehavior;
 
   @override
   _PdfViewerState createState() => _PdfViewerState();
@@ -204,6 +217,7 @@ class _PdfViewerState extends State<PdfViewer> {
         },
         creationParamsCodec: StandardMessageCodec(),
         onPlatformViewCreated: _onPlatformViewCreated,
+        hitTestBehavior: widget.hitTestBehavior,
       );
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       return UiKitView(
@@ -213,6 +227,7 @@ class _PdfViewerState extends State<PdfViewer> {
         },
         creationParamsCodec: const StandardMessageCodec(),
         onPlatformViewCreated: _onPlatformViewCreated,
+        hitTestBehavior: widget.hitTestBehavior,
       );
     }
 

--- a/lib/pdf_flutter.dart
+++ b/lib/pdf_flutter.dart
@@ -100,7 +100,8 @@ class _PDFState extends State<PDF> {
   }
 
   String getFileName() {
-    return getLetterAndDigits(widget.assetsPath ?? widget.networkURL);
+    final baseUrl = widget.networkURL.split('?'); //S3 PresignedURL too long to store, remove the params from url and only use base up to document name
+    return getLetterAndDigits(widget.assetsPath ?? baseUrl[0]);
   }
 
   String getLetterAndDigits(String input) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pedantic: ^1.9.0
-  path_provider: ^1.6.11
-  flutter_cache_manager: ^1.4.1
-  http: ^0.12.1
-  uuid: ^2.1.0
+  pedantic: ^1.9.2
+  path_provider: ^1.6.24
+  flutter_cache_manager: ^2.0.0
+  http: ^0.12.2
+  uuid: ^2.2.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
In order to use `PlatformView` with a `GestureDetector`, e.g. to detect tap events, `hitTestBehaviour` must be set to `PlatformViewHitTestBehavior.transparent`. This way `PlatformView` won't receive events and it'll permit views behind them to receive them.

After exposing `hitTestBehaviour` parameter from this library, it's possible to use GestureDetector:

```
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return GestureDetector(
      behavior: HitTestBehavior.opaque,
      onTap: () {
        // handle onTap
      },
      child: PDF.network(
        url,
        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
      ),
    );
  }
}
```