### PR TITLE
Migrate library and example to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+#### 2.0.0  Migration to null safety
 #### 1.1.4  Upgrade dependencies
 #### 1.1.3  Fixing bug on release mode
 #### 1.1.2  Update README

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,13 +9,14 @@ class PdfApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        debugShowCheckedModeBanner: false,
-        home: Scaffold(
-          appBar: AppBar(
-            title: const Text("pdf_flutter demo"),
-          ),
-          body: PDFListBody(),
-        ));
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text("pdf_flutter demo"),
+        ),
+        body: PDFListBody(),
+      ),
+    );
   }
 }
 
@@ -31,7 +32,7 @@ class _PDFListBodyState extends State<PDFListBody> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          RaisedButton(
+          ElevatedButton(
             child: const Text("Pdf from asset"),
             onPressed: () {
               _navigateToPage(
@@ -44,7 +45,7 @@ class _PDFListBodyState extends State<PDFListBody> {
               );
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             child: const Text("Pdf from network"),
             onPressed: () {
               _navigateToPage(
@@ -57,16 +58,16 @@ class _PDFListBodyState extends State<PDFListBody> {
           ),
           Builder(
             builder: (context) {
-              return RaisedButton(
+              return ElevatedButton(
                 child: const Text("PDF from file"),
                 onPressed: () async {
                   final file = await FilePicker.platform.pickFiles(
                       allowedExtensions: ['pdf'], type: FileType.custom);
-                  if (file?.files[0]?.path != null) {
+                  if (file?.files[0].path != null) {
                     _navigateToPage(
                       title: "PDF from file",
                       child: PDF.file(
-                        File(file.files[0].path),
+                        File(file!.files[0].path!),
                       ),
                     );
                   } else {
@@ -85,7 +86,7 @@ class _PDFListBodyState extends State<PDFListBody> {
     );
   }
 
-  void _navigateToPage({String title, Widget child}) {
+  void _navigateToPage({required String title, required Widget child}) {
     Navigator.push(
       context,
       MaterialPageRoute(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,12 +4,12 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  file_picker: ^2.1.5
+  file_picker: ^3.0.0-nullsafety.2
   pdf_flutter:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,23 @@
 name: pdf_flutter
 description: Displaying PDF from Network, File and assets easily like we display
   Image in Flutter Widget.
-version: 1.1.4
+version: 2.0.0
 homepage: https://github.com/erluxman/pdf_flutter
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
   flutter: ">=1.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^2.1.0
-  http: ^0.12.2
+  flutter_cache_manager: ^3.0.0-nullsafety.1
+  http: ^0.13.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0
 
 flutter:
   plugin:


### PR DESCRIPTION
I migrated the library and the example app to null safety.

closes https://github.com/erluxman/pdf_flutter/issues/23